### PR TITLE
更新合併邏輯與自動年份判斷

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv --year 25
 - DSM 拓撲排序、下三角化與 SCC 分析
 - WBS 依排序重排並加入 Layer、SCC_ID
 - 同一 SCC 任務自動合併並計算工時
+- 合併時自動判斷 Task ID 年份並建立新任務編號，若年份不一致將報錯
+- 新合併任務的 Name 欄位預設留空
 - 以 CSV 匯出排序與合併結果
 
 ## 使用方式

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ def main():
     parser = argparse.ArgumentParser(description="DSM 排序工具")
     parser.add_argument("--dsm", required=True)
     parser.add_argument("--wbs", required=True)
-    parser.add_argument("--year", type=str, default="")
     args = parser.parse_args()
 
     dsm = readDsm(args.dsm)
@@ -30,7 +29,7 @@ def main():
     wbs_sorted.to_csv(out_sorted, index=False, encoding="utf-8-sig")
     print(f"已輸出 {out_sorted}")
 
-    merged = mergeByScc(wbs_sorted, args.year)
+    merged = mergeByScc(wbs_sorted)
     out_merged = Path("merged_wbs.csv")
     merged.to_csv(out_merged, index=False, encoding="utf-8-sig")
     print(f"已輸出 {out_merged}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
 openpyxl
+networkx


### PR DESCRIPTION
## 變更內容
- `mergeByScc` 改為自動解析 Task ID 的年份，若同一群組年份不一致即報錯
- 新合併任務的 `Name` 欄位預設留空
- 移除 CLI `--year` 參數
- README 補充功能說明
- requirements 新增 `networkx`

## 測試
- 安裝依賴並執行 `python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv`
  - 確認 `sorted_wbs.csv` 與 `merged_wbs.csv` 正確產生

------
https://chatgpt.com/codex/tasks/task_e_688b0d89ee3c83238d4ceb28ba9c27d0