### PR TITLE
加入 DSM 方陣檢查與 WBS ID 驗證

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
 from src.dsm_processor import readDsm, buildGraph, computeLayersAndScc
-from src.wbs_processor import readWbs, mergeByScc
+from src.wbs_processor import readWbs, mergeByScc, validateIds
 
 
 
@@ -19,8 +19,7 @@ def main():
 
 
     wbs = readWbs(args.wbs)
-    if "Task ID" not in wbs.columns:
-        raise ValueError("WBS 缺少 Task ID 欄位")
+    validateIds(wbs, dsm)
 
     wbs["Layer"] = wbs["Task ID"].map(layers).fillna(-1).astype(int)
     wbs["SCC_ID"] = wbs["Task ID"].map(scc_id).fillna(-1).astype(int)

--- a/src/dsm_processor.py
+++ b/src/dsm_processor.py
@@ -3,8 +3,12 @@ import networkx as nx
 
 
 def readDsm(path: str) -> pd.DataFrame:
-    """讀取 DSM CSV 並回傳資料框"""
-    return pd.read_csv(path, index_col=0, encoding="utf-8-sig")
+    """讀取 DSM CSV 並檢查方陣"""
+    dsm = pd.read_csv(path, index_col=0, encoding="utf-8-sig")
+    # 檢查列數與欄數是否相等
+    if dsm.shape[0] != dsm.shape[1]:
+        raise ValueError("DSM 必須為方陣，請檢查檔案內容")
+    return dsm
 
 
 def buildGraph(dsm: pd.DataFrame) -> nx.DiGraph:

--- a/src/wbs_processor.py
+++ b/src/wbs_processor.py
@@ -7,6 +7,16 @@ def readWbs(path: str) -> pd.DataFrame:
     return pd.read_csv(path, encoding="utf-8-sig")
 
 
+def validateIds(wbs: pd.DataFrame, dsm: pd.DataFrame) -> None:
+    """確認 WBS 的 Task ID 是否皆存在於 DSM"""
+    if "Task ID" not in wbs.columns:
+        raise ValueError("WBS 缺少 Task ID 欄位")
+    dsm_ids = set(dsm.index.tolist()) | set(dsm.columns.tolist())
+    missing = [tid for tid in wbs["Task ID"] if tid not in dsm_ids]
+    if missing:
+        raise ValueError(f"下列 Task ID 未在 DSM 中找到：{', '.join(missing)}")
+
+
 
 def mergeByScc(wbs: pd.DataFrame, year: str) -> pd.DataFrame:
     """依據 SCC_ID 合併任務並計算新工時"""


### PR DESCRIPTION
## 變更內容
- `readDsm` 讀檔後新增方陣檢查，若列數與欄數不同即擲回例外
- `wbs_processor` 新增 `validateIds` 函式，確認所有 WBS `Task ID` 必須出現在 DSM 中
- `main.py` 於讀取 WBS 後呼叫 `validateIds`，確保兩檔案對應

## 測試
- `pytest -q`（無測試案例）

------
https://chatgpt.com/codex/tasks/task_e_688b195ec54883239ea282a4d1dedd79