### PR TITLE
修正 GUI 並新增測試

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ DSM 矩陣中，若某列某欄的值為 `1`，代表該列任務必須等待該
 ## 執行方式
 
 ```bash
-python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv --year 25
+python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv
 ```
 
 
@@ -55,4 +55,12 @@ pip install -r requirements.txt
 ## 範例資料
 
 `sample_data/` 內含 DSM.csv 與 WBS.csv，可供測試。
+
+## 測試
+
+安裝套件後，可直接於專案根目錄執行 `pytest`，驗證主要功能是否正常。
+
+```bash
+pytest
+```
 

--- a/src/gui.py
+++ b/src/gui.py
@@ -3,10 +3,8 @@
 
 import tkinter as tk
 from tkinter import filedialog, messagebox
-import pandas as pd
-
 from .dsm_processor import readDsm, buildGraph, computeLayersAndScc
-from .wbs_processor import readWbs, mergeByScc
+from .wbs_processor import readWbs, mergeByScc, validateIds
 
 
 class BirdmanApp:
@@ -46,6 +44,7 @@ class BirdmanApp:
             layers, scc_map = computeLayersAndScc(graph)
 
             wbs = readWbs(self.wbsPath.get())
+            validateIds(wbs, dsm)
 
             # 新增 Layer 與 SCC_ID 欄位並依層次排序
             wbs["Layer"] = wbs["Task ID"].map(layers).fillna(-1).astype(int)
@@ -54,7 +53,7 @@ class BirdmanApp:
 
             sorted_wbs.to_csv("sorted_wbs.csv", index=False, encoding="utf-8-sig")
 
-            merged = mergeByScc(sorted_wbs, "")
+            merged = mergeByScc(sorted_wbs)
             merged.to_csv("merged_wbs.csv", index=False, encoding="utf-8-sig")
 
             messagebox.showinfo('完成', '輸出檔已生成')

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.dsm_processor import readDsm, buildGraph, computeLayersAndScc
+from src.wbs_processor import readWbs, validateIds, mergeByScc
+
+
+def test_read_dsm_matrix_check(tmp_path):
+    path = tmp_path / "dsm.csv"
+    # 建立 2x3 非方陣資料
+    df = pd.DataFrame(
+        [[0, 1, 0], [0, 0, 1]], index=["A", "B"], columns=["A", "B", "C"]
+    )
+    df.to_csv(path, encoding="utf-8-sig")
+    with pytest.raises(ValueError):
+        readDsm(path)
+
+def test_validate_ids(tmp_path):
+    dsm_path = tmp_path / "dsm.csv"
+    df = pd.DataFrame([[0,1],[0,0]], index=["A","B"], columns=["A","B"])
+    df.to_csv(dsm_path)
+    dsm = readDsm(dsm_path)
+
+    wbs = pd.DataFrame({"Task ID":["A","C"], "TRF":[1,1]})
+    with pytest.raises(ValueError):
+        validateIds(wbs, dsm)
+
+
+def test_merge_by_scc():
+    data = {
+        "Task ID": ["A24-001", "A24-002"],
+        "TRF": [1, 2],
+        "M": [10, 20],
+        "Layer": [0, 0],
+        "SCC_ID": [0, 0],
+    }
+    wbs = pd.DataFrame(data)
+    merged = mergeByScc(wbs)
+    assert len(merged) == 1
+    new_id = merged.iloc[0]["Task ID"]
+    assert new_id.startswith("M24-")


### PR DESCRIPTION
## Summary
- 修正 GUI 中 mergeByScc 參數與缺少 Task ID 檢查的問題
- 更新 README 使用方式並加入 pytest 說明
- 新增 `tests/test_processors.py` 驗證 DSM 與 WBS 功能

## Testing
- `pytest -q`
- `python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv`

------
https://chatgpt.com/codex/tasks/task_e_688b18902ae08323912a7344e2571445