### PR TITLE
新增 TRF 檢核

### DIFF
--- a/src/wbs_processor.py
+++ b/src/wbs_processor.py
@@ -3,13 +3,22 @@ import pandas as pd
 import re
 
 
+def validateTrf(wbs: pd.DataFrame) -> None:
+    """檢查 TRF 欄位不可為負數"""
+    if "TRF" not in wbs.columns:
+        raise ValueError("WBS 缺少 TRF 欄位")
+    if (wbs["TRF"].astype(float) < 0).any():
+        raise ValueError("TRF 不能為負數")
+
+
 def readWbs(path: str) -> pd.DataFrame:
     """讀取 WBS CSV 並回傳資料框"""
     return pd.read_csv(path, encoding="utf-8-sig")
 
 
 def validateIds(wbs: pd.DataFrame, dsm: pd.DataFrame) -> None:
-    """確認 WBS 的 Task ID 是否皆存在於 DSM"""
+    """確認 WBS 的 Task ID 存在於 DSM，並檢查 TRF"""
+    validateTrf(wbs)
     if "Task ID" not in wbs.columns:
         raise ValueError("WBS 缺少 Task ID 欄位")
     dsm_ids = set(dsm.index.tolist()) | set(dsm.columns.tolist())

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -32,6 +32,18 @@ def test_validate_ids(tmp_path):
         validateIds(wbs, dsm)
 
 
+def test_validate_trf_negative(tmp_path):
+    """檢查 TRF 為負數時是否拋出例外"""
+    dsm_path = tmp_path / "dsm.csv"
+    df = pd.DataFrame([[0]], index=["A"], columns=["A"])
+    df.to_csv(dsm_path)
+    dsm = readDsm(dsm_path)
+
+    wbs = pd.DataFrame({"Task ID": ["A"], "TRF": [-1]})
+    with pytest.raises(ValueError):
+        validateIds(wbs, dsm)
+
+
 def test_merge_by_scc():
     data = {
         "Task ID": ["A24-001", "A24-002"],


### PR DESCRIPTION
## Summary
- 新增 `validateTrf` 用來檢查 WBS 中 `TRF` 不得為負值
- `validateIds` 內加入 `validateTrf` 呼叫
- 新增測試 `test_validate_trf_negative`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b2f83986c8323a79f92c2a56ccfaa