### PR TITLE
修正 README CLI 範例指令

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv
 ### CLI
 
 ```bash
-python main.py --dsm <DSM.csv> --wbs <WBS.csv>
+python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv
 ```
 
 執行後會在目前目錄產生 `sorted_wbs.csv`、`merged_wbs.csv` 及 `sorted_dsm.csv`。


### PR DESCRIPTION
## 變更內容
- 將 README 第 34～36 行的佔位文字改為可直接執行的指令，範例路徑使用 `sample_data`

## 測試
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4c59e5f483239b5ccfa1ad88c869