### PR TITLE
檢查 reorderDsm 的順序列表

### DIFF
--- a/src/dsm_processor.py
+++ b/src/dsm_processor.py
@@ -55,5 +55,7 @@ def computeLayersAndScc(G: nx.DiGraph) -> tuple[dict, dict]:
 
 def reorderDsm(dsm: pd.DataFrame, order: list[str]) -> pd.DataFrame:
     """依指定順序重新排列 DSM 的列與欄"""
+    if set(order) != set(dsm.index):
+        raise ValueError("指定的順序與 DSM 任務不符")
     return dsm.loc[order, order]
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -69,3 +69,19 @@ def test_reorder_dsm():
     assert list(reordered.index) == order
     assert list(reordered.columns) == order
 
+
+def test_reorder_dsm_missing_task():
+    """當順序缺少任務時應拋出錯誤"""
+    dsm = pd.DataFrame([[0, 0], [0, 0]], index=["A", "B"], columns=["A", "B"])
+    order = ["A"]
+    with pytest.raises(ValueError):
+        reorderDsm(dsm, order)
+
+
+def test_reorder_dsm_extra_task():
+    """當順序多出任務時應拋出錯誤"""
+    dsm = pd.DataFrame([[0]], index=["A"], columns=["A"])
+    order = ["A", "B"]
+    with pytest.raises(ValueError):
+        reorderDsm(dsm, order)
+


### PR DESCRIPTION
## 變更內容
- 在 `reorderDsm` 加入順序與 DSM 任務集合是否相符的檢查
- 新增兩個單元測試，驗證缺少或多出任務時會拋出例外

## 測試結果
- `pytest -q` 全數通過

------
https://chatgpt.com/codex/tasks/task_e_688b4c5e9c388323810f8cfcbc5b7b32