### PR TITLE
Add dependency graph visualizer and JSON config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ DSM 矩陣中，若某列某欄的值為 `1`，代表該列任務必須等待該
 ## 執行方式
 
 ```bash
-python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv
+python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv --config config.json
 ```
 
 完成後會在目前目錄生成 `sorted_wbs.csv`、`merged_wbs.csv`，以及 `sorted_dsm.csv`。
@@ -29,13 +29,14 @@ python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv
 - 新合併任務的 Name 欄位預設留空
 - 以 CSV 匯出排序與合併結果
 - GUI 可在 DSM 分頁正確顯示 Task ID 行表頭
+- 依賴性視覺化：新分頁展示任務間依賴圖及 SCC 群組
 
 ## 使用方式
 
 ### CLI
 
 ```bash
-python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv
+python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv --config config.json
 ```
 
 執行後會在目前目錄產生 `sorted_wbs.csv`、`merged_wbs.csv` 及 `sorted_dsm.csv`。
@@ -55,6 +56,11 @@ python -m src.gui_qt
 - 表格預覽（像 Excel，可橫向捲動、欄位標題清楚）
 - DSM 依賴格自動標紅
 - 匯出功能完整
+- 新增依賴關係圖分頁，能以圖形呈現任務依賴
+
+## 依賴視覺化範例
+
+(此處可放入依賴關係圖截圖)
 
 > **僅提供 PyQt5 版 GUI，請確保已安裝對應套件。**
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,14 @@
+{
+  "merge_k_params": {
+    "base": 1.0,
+    "trf_scale": 1.0,
+    "trf_divisor": 10.0,
+    "n_coef": 0.05,
+    "override": null
+  },
+  "visualization_params": {
+    "node_color": "skyblue",
+    "scc_color_palette": ["#FFD700", "#FF8C00", "#FF6347", "#DA70D6", "#9370DB"],
+    "font_size": 8
+  }
+}

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+import json
 from src.dsm_processor import readDsm, buildGraph, computeLayersAndScc, reorderDsm
 from src.wbs_processor import readWbs, mergeByScc, validateIds
 
@@ -9,6 +10,7 @@ def main():
     parser = argparse.ArgumentParser(description="DSM 排序工具")
     parser.add_argument("--dsm", required=True)
     parser.add_argument("--wbs", required=True)
+    parser.add_argument("--config", default="config.json")
     args = parser.parse_args()
 
     dsm = readDsm(args.dsm)
@@ -33,7 +35,10 @@ def main():
     sorted_dsm.to_csv(out_dsm, encoding="utf-8-sig")
     print(f"已輸出 {out_dsm}")
 
-    merged = mergeByScc(wbs_sorted)
+    with open(args.config, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+    k_params = config.get('merge_k_params', {})
+    merged = mergeByScc(wbs_sorted, k_params)
     out_merged = Path("merged_wbs.csv")
     merged.to_csv(out_merged, index=False, encoding="utf-8-sig")
     print(f"已輸出 {out_merged}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 openpyxl
 networkx
+matplotlib

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -1,0 +1,36 @@
+"""視覺化相關函式"""
+import networkx as nx
+from matplotlib.figure import Figure
+import matplotlib.pyplot as plt
+
+
+def create_dependency_graph_figure(G: nx.DiGraph, sccMap: dict, vizParams: dict) -> Figure:
+    """建立任務依賴關係圖
+
+    依據 ``sccMap`` 提供的 SCC_ID 上色，未屬於任何 SCC 的節點使用
+    ``vizParams['node_color']``，其餘則循環套用 ``vizParams['scc_color_palette']``。
+    回傳 Matplotlib ``Figure`` 物件，可嵌入至 PyQt5 介面。
+    """
+    fig = Figure(figsize=(6, 4))
+    ax = fig.add_subplot(111)
+
+    palette = vizParams.get('scc_color_palette', [])
+    default_color = vizParams.get('node_color', 'skyblue')
+    font_size = vizParams.get('font_size', 8)
+
+    colors = []
+    for node in G.nodes:
+        scc_id = sccMap.get(node, -1)
+        if scc_id == -1 or scc_id is None:
+            colors.append(default_color)
+        else:
+            if palette:
+                colors.append(palette[scc_id % len(palette)])
+            else:
+                colors.append(default_color)
+
+    pos = nx.spring_layout(G)
+    nx.draw(G, pos, ax=ax, with_labels=True, node_color=colors, font_size=font_size)
+    ax.axis('off')
+    fig.tight_layout()
+    return fig


### PR DESCRIPTION
## Summary
- switch config format to `config.json`
- add support for reading merge parameters from JSON
- return graph from `process_dsm`
- show dependency graph tab in GUI
- provide helper for plotting graph
- update README and requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8c683a8083238e6409621e96408e