### PR TITLE
Add CPM algorithm module

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,5 +16,12 @@
       "#9370DB"
     ],
     "font_size": 8
+  },
+  "cmp_params": {
+    "work_hours_per_day": 8,
+    "working_days_per_week": 5,
+    "default_duration_field": "Te_expert",
+    "project_start_date": null,
+    "time_unit": "hours"
   }
 }

--- a/src/cpm_processor.py
+++ b/src/cpm_processor.py
@@ -1,0 +1,94 @@
+import pandas as pd
+import networkx as nx
+from datetime import datetime, timedelta
+from typing import Dict, List, Tuple
+
+
+def cpmForwardPass(G: nx.DiGraph, durations: Dict[str, float]) -> Dict[str, Tuple[float, float]]:
+    """CPM 正向計算，回傳最早開始與最早完成時間"""
+    es: Dict[str, float] = {}
+    ef: Dict[str, float] = {}
+    for node in nx.topological_sort(G):
+        preds = list(G.predecessors(node))
+        if preds:
+            es[node] = max(ef[p] for p in preds)
+        else:
+            es[node] = 0.0
+        ef[node] = es[node] + durations.get(node, 0)
+    return {n: (es[n], ef[n]) for n in G.nodes}
+
+
+def cpmBackwardPass(G: nx.DiGraph, durations: Dict[str, float], projectEnd: float) -> Dict[str, Tuple[float, float]]:
+    """CPM 反向計算，回傳最晚開始與最晚完成時間"""
+    ls: Dict[str, float] = {}
+    lf: Dict[str, float] = {}
+    order = list(nx.topological_sort(G))
+    for node in reversed(order):
+        succs = list(G.successors(node))
+        if succs:
+            lf[node] = min(ls[s] for s in succs)
+        else:
+            lf[node] = projectEnd
+        ls[node] = lf[node] - durations.get(node, 0)
+    return {n: (ls[n], lf[n]) for n in G.nodes}
+
+
+def calculateSlack(forwardData: Dict[str, Tuple[float, float]], backwardData: Dict[str, Tuple[float, float]], G: nx.DiGraph) -> pd.DataFrame:
+    """計算總鬆弛與自由鬆弛時間"""
+    records = []
+    for node in G.nodes:
+        es, ef = forwardData[node]
+        ls, lf = backwardData[node]
+        tf = ls - es
+        if list(G.successors(node)):
+            ff = min(forwardData[s][0] for s in G.successors(node)) - ef
+        else:
+            ff = tf
+        records.append({
+            "Task ID": node,
+            "ES": es,
+            "EF": ef,
+            "LS": ls,
+            "LF": lf,
+            "TF": tf,
+            "FF": ff,
+            "Critical": tf == 0,
+        })
+    df = pd.DataFrame(records).set_index("Task ID")
+    return df
+
+
+def findCriticalPath(slackData: pd.DataFrame) -> List[str]:
+    """根據總鬆弛時間為 0 識別關鍵路徑"""
+    critical = slackData[slackData["TF"] == 0]
+    critical = critical.sort_values("ES")
+    return critical.index.tolist()
+
+
+# 時間相關輔助函式
+
+def convertHoursToDays(hours: float, workHoursPerDay: float = 8) -> float:
+    """將工時轉換為工作天數"""
+    return hours / workHoursPerDay
+
+
+def addWorkingDays(startDate: str, days: float) -> str:
+    """計算加入工作天數後的日期（排除週末）"""
+    date = datetime.strptime(startDate, "%Y-%m-%d")
+    full_days = int(days)
+    remaining = days - full_days
+    while full_days > 0:
+        date += timedelta(days=1)
+        if date.weekday() < 5:
+            full_days -= 1
+    if remaining > 0:
+        date += timedelta(days=remaining)
+    return date.strftime("%Y-%m-%d")
+
+
+def extractDurationFromWbs(wbs: pd.DataFrame, durationField: str = "Te_expert") -> Dict[str, float]:
+    """從 WBS 資料框提取工期資訊"""
+    if durationField not in wbs.columns:
+        raise KeyError(f"WBS 缺少 {durationField} 欄位")
+    return dict(zip(wbs["Task ID"], wbs[durationField].astype(float)))
+

--- a/tests/test_cpm_processor.py
+++ b/tests/test_cpm_processor.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import networkx as nx
+import pandas as pd
+from src.cpm_processor import (
+    cpmForwardPass,
+    cpmBackwardPass,
+    calculateSlack,
+    findCriticalPath,
+)
+
+
+def build_sample_graph():
+    tasks = {
+        'A': {'duration': 3, 'predecessors': []},
+        'B': {'duration': 4, 'predecessors': ['A']},
+        'C': {'duration': 2, 'predecessors': ['A']},
+        'D': {'duration': 3, 'predecessors': ['B', 'C']}
+    }
+    G = nx.DiGraph()
+    for tid, data in tasks.items():
+        G.add_node(tid)
+        for pre in data['predecessors']:
+            G.add_edge(pre, tid)
+    durations = {tid: data['duration'] for tid, data in tasks.items()}
+    return G, durations
+
+
+def test_cpm_calculation():
+    G, durations = build_sample_graph()
+    forward = cpmForwardPass(G, durations)
+    project_end = max(v[1] for v in forward.values())
+    backward = cpmBackwardPass(G, durations, project_end)
+    slack_df = calculateSlack(forward, backward, G)
+    critical = findCriticalPath(slack_df)
+
+    assert forward['A'] == (0, 3)
+    assert forward['B'] == (3, 7)
+    assert forward['C'] == (3, 5)
+    assert backward['D'] == (7, 10)
+    assert slack_df.at['C', 'TF'] == 2
+    assert critical == ['A', 'B', 'D']
+


### PR DESCRIPTION
## Summary
- implement CPM calculations in new `cpm_processor` module
- extend `config.json` with `cmp_params` for CPM settings
- create basic tests for CPM logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c488d8bf08323bbcbc38c38c77453