### PR TITLE
更新 WBS 欄位並強化甘特圖標題

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ pip install -r requirements.txt
 ## WBS.csv 欄位詳解
 
 - `TRF`：任務複雜度係數，數值不得為負。
-- `M`：專家評估的最可能工時。
+- `M_expert`：專家評估的最可能工時。
 - `O_expert`：專家的樂觀工時。
 - `P_expert`：專家的悲觀工時。
-- `Te_expert`：依 PERT 公式 `(O + 4*M + P) / 6` 計算的期望工時。
+- `Te_expert`：依 PERT 公式 `(O + 4*M_expert + P) / 6` 計算的期望工時。
 - `K_adj`：估算新手工時的調整係數。
 - `O_newbie`、`M_newbie`、`P_newbie`：將專家對應的時間乘以 `K_adj` 後得出的新手估算工時。
 - `Te_newbie`：根據新手時間以 PERT 公式計算出的期望工時，也是系統新的預設工時。

--- a/sample_data/WBS.csv
+++ b/sample_data/WBS.csv
@@ -1,4 +1,4 @@
-﻿Task ID,Name,Category,Novelty,Complexity,Dependency,TRF,M,O_expert,P_expert,Te_expert,K_base,K_adj,O_newbie,M_newbie,P_newbie,Te_newbie
+﻿Task ID,Name,Category,Novelty,Complexity,Dependency,TRF,M_expert,O_expert,P_expert,Te_expert,K_base,K_adj,O_newbie,M_newbie,P_newbie,Te_newbie
 0X26-001,全機總體佈局與性能目標定義,0X,5,5,5,1,80,80,200,100,3,3.45,276,276,690,345
 A26-001,全機空氣動力學概念設計與分析,A,5,5,5,1,120,120,300,150,3,3.45,414,414,1035,517.5
 S26-001,全機結構概念與載重路徑設計,S,5,5,5,1,100,100,250,125,3,3.45,345,345,862.5,431.25

--- a/src/gui_qt.py
+++ b/src/gui_qt.py
@@ -894,7 +894,7 @@ class BirdmanQtApp(QMainWindow):
         if success:
             self.runCmpAnalysis()
 
-    def drawGanttChart(self, cpmData, durations):
+    def drawGanttChart(self, cpmData, durations, roleText):
         """繪製甘特圖"""
         try:
             self.gantt_figure.clear()
@@ -953,7 +953,7 @@ class BirdmanQtApp(QMainWindow):
             # 設定標籤和標題
             ax.set_xlabel('時間 (小時)', fontsize=11, fontweight='bold')
             ax.set_title(
-                '專案甘特圖 (紅色為關鍵路徑)',
+                f'專案甘特圖 - {roleText} (紅色為關鍵路徑)',
                 fontsize=14,
                 pad=20,
             )
@@ -1020,7 +1020,9 @@ class BirdmanQtApp(QMainWindow):
         self.cmp_result = wbs_df
         self.critical_path = findCriticalPath(cpm_df)
         self.cmp_result_view.setModel(PandasModel(wbs_df.head(100)))
-        self.drawGanttChart(cpm_df, durations)
+        role_selected = self.role_selection_combo.currentText()
+        role_text = '新手' if '新手' in role_selected else '專家'
+        self.drawGanttChart(cpm_df, durations, role_text)
 
     def exportCmpResult(self):
         """匯出 CPM 分析結果"""

--- a/src/wbs_processor.py
+++ b/src/wbs_processor.py
@@ -50,7 +50,7 @@ def mergeByScc(
     自訂計算係數的相關參數。
     """
     time_cols = [
-        "M",
+        "M_expert",
         "O_expert",
         "P_expert",
         "Te_expert",

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -51,7 +51,7 @@ def test_merge_by_scc():
     data = {
         "Task ID": ["A24-001", "A24-002"],
         "TRF": [1, 2],
-        "M": [10, 20],
+        "M_expert": [10, 20],
         "Layer": [0, 0],
         "SCC_ID": [0, 0],
     }


### PR DESCRIPTION
## Summary
- 將 WBS 範例與測試改為 `M_expert` 欄位
- `mergeByScc` 改以 `M_expert` 為計算基礎
- 甘特圖在角色切換時動態顯示對應標題
- 調整說明文件

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688caaf99a0c8323a366c509664c1ab3