### PR TITLE
Add CPM result export menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ python -m src.gui_qt
    - 深色/淺色主題切換
    - 匯出原始與合併後依賴關係圖
    - 匯出甘特圖與 CPM 分析結果
+   - CPM 分析結果可匯出乾淨報告（CSV/Excel）
    - CPM 分析可切換 O、P、M、TE 或 All Scenarios
 
 3. **參數調整**


### PR DESCRIPTION
## Summary
- add helper `_create_cpm_display_df` for a cleaner CPM result table
- display simplified CPM data in GUI and expose the current table via `current_display_cpm_df`
- allow exporting the simplified CPM result as CSV/Excel from the menu
- document CPM report export in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb212a3e48323b6ff5764bda195b5