### PR TITLE
Fix dark mode refresh

### DIFF
--- a/src/gui_qt.py
+++ b/src/gui_qt.py
@@ -1101,7 +1101,15 @@ class BirdmanQtApp(QMainWindow):
 
             # 設定 Y 軸標籤
             ax.set_yticks(y_positions)
-            ax.set_yticklabels(tasks, fontsize=10, fontweight='bold')
+            ax.set_yticklabels(
+                tasks,
+                fontsize=10,
+                fontweight='bold',
+                color=plt.rcParams['text.color'],
+            )
+
+            ax.tick_params(axis='x', colors=plt.rcParams['text.color'])
+            ax.tick_params(axis='y', colors=plt.rcParams['text.color'])
 
             # 加強網格線
             ax.grid(
@@ -1137,6 +1145,7 @@ class BirdmanQtApp(QMainWindow):
                         va='center',
                         fontsize=9,
                         alpha=0.7,
+                        color=plt.rcParams['text.color'],
                     )
 
             # 反轉 Y 軸
@@ -1292,6 +1301,8 @@ class BirdmanQtApp(QMainWindow):
 
         # 重繪圖表
         self.redraw_graph()
+        if self.gantt_results:
+            self.update_gantt_display()
 
     def redraw_graph(self):
         """重新繪製依賴關係圖"""

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -88,7 +88,7 @@ def create_dependency_graph_figure(
         node_size=2500,
         node_color=node_colors,
         font_size=viz_params.get('font_size', 9),
-        font_color='black',
+        font_color=plt.rcParams['text.color'],
         font_weight='bold',
         width=1.2,
         edge_color='gray',


### PR DESCRIPTION
## Summary
- refresh gantt chart when toggling dark mode
- adjust tick and label colours to respect theme
- use current text colour in dependency graph

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd7da2ad483239112c6fcb18f7a24