### PR TITLE
Fix edge color in dependency graph

### DIFF
--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -95,7 +95,7 @@ def create_dependency_graph_figure(
         font_color=plt.rcParams['text.color'],
         font_weight='bold',
         width=1.2,
-        edge_color=plt.rcParams['axes.edgecolor'],
+        edge_color=plt.rcParams['grid.color'],
         arrowsize=20,
         connectionstyle='arc3,rad=0.1'
     )


### PR DESCRIPTION
## Summary
- use theme grid color for graph edges

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdced3b808323a4ad1dd777d87dd1