### PR TITLE
Add Monte Carlo schedule simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
    - 甘特圖視覺化
    - 完整的時程資訊
    - 預設使用 `Te_newbie` 作為 CPM 計算工期欄位
+   - 新增蒙地卡羅模擬，可評估工期分佈
 
 4. **匯出功能**
    - 支援 SVG/PNG 格式
@@ -89,6 +90,7 @@ python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv --config conf
 ```
 執行後會在目前目錄產生 `sorted_wbs.csv`、`merged_wbs.csv` 及 `sorted_dsm.csv`。
 若加上 `--cmp` 參數，會同時輸出 `cmp_analysis.csv`，並可使用 `--export-gantt` 匯出甘特圖、`--export-graph` 匯出依賴關係圖。工期欄位可透過 `--duration-field` 指定。
+若需評估工期分佈，可加入 `--monte-carlo 500` 執行 500 次模擬，信心水準可用 `--mc-confidence 0.9` 指定（預設為 0.9）。
 
 ### GUI（推薦 PyQt5 進階版）
 

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+from src.cpm_processor import monteCarloSchedule  # noqa: E402
+from tests.test_cpm_processor import build_sample_graph  # noqa: E402
+
+
+def test_monte_carlo_schedule():
+    G, durations = build_sample_graph()
+    result = monteCarloSchedule(
+        G,
+        {k: 1 for k in durations},
+        durations,
+        {k: d * 2 for k, d in durations.items()},
+        nIterations=10,
+        confidence=0.9,
+    )
+    assert 'average' in result
+    assert len(result['samples']) == 10
+    assert result['min'] <= result['max']


### PR DESCRIPTION
## Summary
- add Monte Carlo schedule function in `cpm_processor`
- support CLI options `--monte-carlo` and `--mc-confidence`
- show simulation result statistics after CPM analysis
- document new feature in README
- add test for Monte Carlo schedule

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce2ccfa14832388bfba4b0293bc14