### PR TITLE
修正 flake8 违规並更新說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,8 @@ pip install -r requirements.txt
 ```bash
 pytest
 ```
+安裝完成後，也可執行 `flake8` 確保程式碼格式一致。
+
+```bash
+flake8
+```

--- a/src/gui_qt.py
+++ b/src/gui_qt.py
@@ -1538,7 +1538,10 @@ class BirdmanQtApp(QMainWindow):
             )
 
             project_end = schedule.pop("ProjectEnd", 0)
-            result_text = f"<b>RCPSP 排程結果 (總工期: {project_end:.2f} 小時):</b><br><br>"
+            result_text = (
+                f"<b>RCPSP 排程結果 (總工期: {project_end:.2f} 小時):"
+                "</b><br><br>"
+            )
             result_text += "<table border='1' style='width:100%'>"
             result_text += "<tr><th>任務 ID</th><th>開始時間 (小時)</th></tr>"
             for task, start_time in sorted(schedule.items()):


### PR DESCRIPTION
## Summary
- 修正 `src/gui_qt.py` 長度超過 79 字元的程式碼
- README 新增 flake8 執行說明

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cf0da93988323a7097e81b6550651