### PR TITLE
feat: 加入 main_window 獨立執行入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ pip install -r requirements.txt
 python -m src.gui_qt
 ```
 
+#### 蒙地卡羅模擬快速視窗
+
+```bash
+python src/ui/main_window.py
+```
+
+可獨立開啟含「開始模擬」按鈕的蒙地卡羅介面。
+
 #### 進階 GUI 功能
 
 1. **檔案操作**

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -237,3 +237,14 @@ class MainWindow(QWidget):
         ax.set_xlabel('工時 (小時)')
         ax.set_ylabel('頻率')
         self.mc_canvas.draw()
+
+
+# 提供獨立執行的入口
+if __name__ == "__main__":
+    import sys
+    from PyQt5.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+    win = MainWindow()
+    win.show()
+    sys.exit(app.exec_())


### PR DESCRIPTION
## Summary
- 在 `src/ui/main_window.py` 最後新增獨立執行入口，可直接啟動含「開始模擬」按鈕的蒙地卡羅介面。
- 更新 README，補充 `python src/ui/main_window.py` 的使用方式。

## Testing
- `flake8 && echo 'flake8 passed'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d87e089fc83238b0a459180938ff8