### PR TITLE
調整預設工期欄位為 Te_newbie

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv --config conf
 ```
 
 執行後會在目前目錄產生 `sorted_wbs.csv`、`merged_wbs.csv` 及 `sorted_dsm.csv`。
-若加上 `--cmp` 參數，會同時輸出 `cmp_analysis.csv`，並可使用 `--export-gantt` 匯出甘特圖、`--export-graph` 匯出依賴關係圖。工期欄位可透過 `--duration-field` 指定。
+若加上 `--cmp` 參數，會同時輸出 `cmp_analysis.csv`，並可使用 `--export-gantt` 匯出甘特圖、`--export-graph` 匯出依賴關係圖。工期欄位預設採用 `config.json` 中的 `default_duration_field`（預設 `Te_newbie`），亦可透過 `--duration-field` 指定。
 若需評估工期分佈，可加入 `--monte-carlo 500` 執行 500 次模擬，信心水準可用 `--mc-confidence 0.9` 指定（預設為 0.9）。
 
 若需執行資源受限排程，可加入 `--rcpsp-opt`，將產生 `rcpsp_schedule.csv`。

--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
   "cmp_params": {
     "work_hours_per_day": 8,
     "working_days_per_week": 5,
-    "default_duration_field": "Te_expert",
+    "default_duration_field": "Te_newbie",
     "project_start_date": null,
     "time_unit": "hours"
   }

--- a/main.py
+++ b/main.py
@@ -164,7 +164,7 @@ def main():
         print("開始執行 RCPSP 排程...")
         cmp_params = config.get("cmp_params", {})
         duration_field = args.duration_field or cmp_params.get(
-            "default_duration_field", "Te_expert"
+            "default_duration_field", "Te_newbie"
         )
         schedule = solveRcpsp(merged_graph, merged, duration_field)
         merged["Start"] = merged["Task ID"].map(schedule).fillna(0)
@@ -190,7 +190,7 @@ def main():
         print("開始執行 CPM 分析...")
         cmp_params = config.get('cmp_params', {})
         duration_field = args.duration_field or cmp_params.get(
-            'default_duration_field', 'Te_expert'
+            'default_duration_field', 'Te_newbie'
         )
 
         # 以合併後的 WBS 取得工時

--- a/tests/test_cli_cmp.py
+++ b/tests/test_cli_cmp.py
@@ -13,7 +13,7 @@ def test_cli_cpm(tmp_path):
     dsm = "Task ID,A,B,C\nA,0,1,1\nB,0,0,0\nC,0,0,0\n"
     dsm_path.write_text(dsm, encoding='utf-8')
 
-    wbs = "Task ID,TRF,Te_expert\nA,1,1\nB,1,1\nC,1,1\n"
+    wbs = "Task ID,TRF,Te_newbie\nA,1,1\nB,1,1\nC,1,1\n"
     wbs_path.write_text(wbs, encoding='utf-8')
 
     cmd = [


### PR DESCRIPTION
## 摘要
- 將 CLI 中 CMP 與 RCPSP 的預設工期欄位改為 `Te_newbie`
- 更新 `config.json` 與測試資料以符合新預設
- README 說明同步調整，明確指出未指定時採用 `Te_newbie`

## 測試
- `flake8`（整體：GUI 相關檔案仍有多處樣式警告）
- `flake8 main.py tests/test_cli_cmp.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e022d96dc83239e3578fbc5863f70