### PR TITLE
refactor: adopt camelCase naming

### DIFF
--- a/src/dsm_processor.py
+++ b/src/dsm_processor.py
@@ -63,24 +63,24 @@ def reorderDsm(dsm: pd.DataFrame, order: list[str]) -> pd.DataFrame:
     return dsm.loc[order, order]
 
 
-def process_dsm(
+def processDsm(
     dsm: pd.DataFrame,
     wbs: pd.DataFrame
 ) -> tuple[pd.DataFrame, pd.DataFrame, nx.DiGraph]:
     """整合 DSM 與 WBS，回傳排序後的 DSM、WBS 以及依賴圖"""
     G = buildGraph(dsm)
-    layers, scc_map = computeLayersAndScc(G)
+    layers, sccMap = computeLayersAndScc(G)
 
-    wbs_sorted = wbs.copy()
-    wbs_sorted["Layer"] = wbs_sorted["Task ID"].map(
+    wbsSorted = wbs.copy()
+    wbsSorted["Layer"] = wbsSorted["Task ID"].map(
         layers).fillna(-1).astype(int)
-    wbs_sorted["SCC_ID"] = wbs_sorted["Task ID"].map(
-        scc_map).fillna(-1).astype(int)
-    wbs_sorted = wbs_sorted.sort_values(
+    wbsSorted["SCC_ID"] = wbsSorted["Task ID"].map(
+        sccMap).fillna(-1).astype(int)
+    wbsSorted = wbsSorted.sort_values(
         by=["Layer", "Task ID"]).reset_index(drop=True)
 
-    sorted_dsm = reorderDsm(dsm, wbs_sorted["Task ID"].tolist())
-    return sorted_dsm, wbs_sorted, G
+    sortedDsm = reorderDsm(dsm, wbsSorted["Task ID"].tolist())
+    return sortedDsm, wbsSorted, G
 
 
 def buildTaskMapping(

--- a/src/gui_qt.py
+++ b/src/gui_qt.py
@@ -46,7 +46,7 @@ from PyQt5.QtCore import QAbstractTableModel
 
 from .dsm_processor import (
     readDsm,
-    process_dsm,
+    processDsm,
     buildTaskMapping,
     buildMergedDsm,
 )
@@ -920,7 +920,7 @@ class BirdmanQtApp(QMainWindow):
             # 統一設定圖表主題顏色
             self.configure_chart_theme()
 
-            sorted_dsm, sorted_wbs, graph = process_dsm(dsm, wbs)
+            sorted_dsm, sorted_wbs, graph = processDsm(dsm, wbs)
             self.sorted_wbs = self._add_no_column(sorted_wbs)
             self.sorted_dsm = sorted_dsm
             self.graph = graph  # 儲存圖形物件供後續使用
@@ -937,7 +937,7 @@ class BirdmanQtApp(QMainWindow):
                 self.merged_dsm,
                 merged_sorted_wbs,
                 self.merged_graph,
-            ) = process_dsm(
+            ) = processDsm(
                 merged_dsm,
                 merged,
             )


### PR DESCRIPTION
## Summary
- rename figure helpers to saveFigure and saveGanttChart, and use camelCase variables
- expose DSM processing as processDsm and update GUI imports

## Testing
- `flake8` *(fails: src/gui_qt.py:276:1: W293 blank line contains whitespace, ...)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e025bf4248323ad9bf43a5d5c5d8c