### PR TITLE
修正程式碼以符合 flake8 規範

### DIFF
--- a/src/gui_qt.py
+++ b/src/gui_qt.py
@@ -273,7 +273,7 @@ class BirdmanQtApp(QMainWindow):
         self.merged_graph_canvas = None
         self.gantt_figure = None
         self.gantt_canvas = None
-        
+
         # 蒙地卡羅模擬相關初始化
         self.mc_figure = None
         self.mc_canvas = None
@@ -326,7 +326,7 @@ class BirdmanQtApp(QMainWindow):
             text_color = 'white'
             grid_color = '#555555'
             edge_color = '#666666'
-            
+
             # 更新 matplotlib 的全域設定
             plt.rcParams.update({
                 'figure.facecolor': dark_bg_color,
@@ -348,7 +348,7 @@ class BirdmanQtApp(QMainWindow):
             text_color = 'black'
             grid_color = '#cccccc'
             edge_color = 'black'
-            
+
             plt.rcParams.update({
                 'figure.facecolor': light_bg_color,
                 'axes.facecolor': light_bg_color,
@@ -368,16 +368,16 @@ class BirdmanQtApp(QMainWindow):
         """將關鍵路徑節點轉換為關鍵路徑邊線集合"""
         if not critical_path_nodes or len(critical_path_nodes) < 2:
             return set()
-        
+
         critical_edges = set()
         for i in range(len(critical_path_nodes) - 1):
             current_node = critical_path_nodes[i]
             next_node = critical_path_nodes[i + 1]
-            
+
             # 檢查圖中是否存在這個邊
             if graph.has_edge(current_node, next_node):
                 critical_edges.add((current_node, next_node))
-        
+
         return critical_edges
 
     def closeEvent(self, event):
@@ -388,39 +388,40 @@ class BirdmanQtApp(QMainWindow):
                 if self.mc_thread.isRunning():
                     # 詢問用戶是否要強制關閉
                     reply = QMessageBox.question(
-                        self, 
-                        '確認關閉', 
+                        self,
+                        '確認關閉',
                         '蒙地卡羅模擬正在進行中，強制關閉可能導致數據丟失。\n確定要關閉應用程式嗎？',
                         QMessageBox.Yes | QMessageBox.No,
                         QMessageBox.No
                     )
-                    
+
                     if reply == QMessageBox.No:
                         event.ignore()
                         return
-                    
+
                     # 用戶選擇強制關閉，停止線程和工作對象
-                    if hasattr(self, 'mc_worker') and self.mc_worker is not None:
+                    if hasattr(
+                            self, 'mc_worker') and self.mc_worker is not None:
                         # 斷開信號連接，避免在清理過程中觸發信號
                         try:
                             self.mc_worker.progress.disconnect()
                             self.mc_worker.finished.disconnect()
                         except (RuntimeError, TypeError):
                             pass
-                    
+
                     # 終止線程
                     self.mc_thread.terminate()
                     self.mc_thread.wait(3000)  # 等待3秒讓線程正常結束
-                    
+
                     if self.mc_thread.isRunning():
                         # 如果還在運行，強制終止
                         self.mc_thread.quit()
                         self.mc_thread.wait(1000)
-                        
+
             except RuntimeError:
                 # 線程已被刪除，正常繼續
                 pass
-        
+
         # 接受關閉事件
         event.accept()
 
@@ -711,7 +712,7 @@ class BirdmanQtApp(QMainWindow):
         )
         self.tab_cmp_result.setLayout(QVBoxLayout())
         cpm_top_layout = QHBoxLayout()
-        
+
         # 左邊完整的控制區域
         cpm_display_label = QLabel('顯示模式：')
         cpm_top_layout.addWidget(cpm_display_label)
@@ -720,7 +721,7 @@ class BirdmanQtApp(QMainWindow):
             self.update_cpm_display
         )
         cpm_top_layout.addWidget(self.cpm_display_combo)
-        
+
         cpm_top_layout.addStretch()
         self.tab_cmp_result.layout().addLayout(cpm_top_layout)
         self.tab_cmp_result.layout().addWidget(self.cmp_result_view)
@@ -772,10 +773,10 @@ class BirdmanQtApp(QMainWindow):
         # 增大直方圖尺寸
         self.mc_figure = Figure(figsize=(8, 5))
         self.mc_canvas = FigureCanvas(self.mc_figure)
-        
+
         # 初始化空白圖表，根據當前模式設定顏色
         self.initialize_monte_carlo_chart()
-        
+
         mc_result_layout.addWidget(self.mc_canvas)
 
         # 統計資訊區域，調整寬度比例
@@ -783,26 +784,26 @@ class BirdmanQtApp(QMainWindow):
         mc_stats_widget.setMaximumWidth(220)  # 限制統計區域寬度
         mc_stats_layout = QVBoxLayout()
         mc_stats_widget.setLayout(mc_stats_layout)
-        
+
         self.mc_mean_label = QLabel('平均總工時：-')
         self.mc_std_label = QLabel('標準差：-')
         self.mc_p50_label = QLabel('50% 完成機率：-')
         self.mc_p85_label = QLabel('85% 完成機率：-')
         self.mc_p95_label = QLabel('95% 完成機率：-')
-        
+
         # 設定標籤的字體和對齊
-        for label in [self.mc_mean_label, self.mc_std_label, self.mc_p50_label, 
-                     self.mc_p85_label, self.mc_p95_label]:
+        for label in [self.mc_mean_label, self.mc_std_label, self.mc_p50_label,
+                      self.mc_p85_label, self.mc_p95_label]:
             label.setAlignment(Qt.AlignLeft)
             label.setStyleSheet("padding: 2px; margin: 1px;")
-        
+
         mc_stats_layout.addWidget(self.mc_mean_label)
         mc_stats_layout.addWidget(self.mc_std_label)
         mc_stats_layout.addWidget(self.mc_p50_label)
         mc_stats_layout.addWidget(self.mc_p85_label)
         mc_stats_layout.addWidget(self.mc_p95_label)
         mc_stats_layout.addStretch()
-        
+
         mc_result_layout.addWidget(mc_stats_widget)
 
         # --- 按鈕連接 ---
@@ -811,21 +812,21 @@ class BirdmanQtApp(QMainWindow):
 
         # 甘特圖情境切換下拉選單
         gantt_top_layout = QHBoxLayout()
-        
+
         # 左邊角色選擇
         role_label = QLabel('角色：')
         gantt_top_layout.addWidget(role_label)
         self.role_selection_combo = QComboBox()
         self.role_selection_combo.addItems(['新手 (Novice)', '專家 (Expert)'])
         gantt_top_layout.addWidget(self.role_selection_combo)
-        
+
         # 中間的顯示模式選擇
         self.gantt_display_combo = QComboBox()
         self.gantt_display_combo.currentIndexChanged.connect(
             self.update_gantt_display
         )
         gantt_top_layout.addWidget(self.gantt_display_combo)
-        
+
         # 右邊的總工時顯示
         self.total_hours_label = QLabel('總工時：0 小時')
         gantt_top_layout.addWidget(self.total_hours_label)
@@ -836,7 +837,7 @@ class BirdmanQtApp(QMainWindow):
         self.gantt_container = QWidget()
         self.gantt_container.setLayout(QVBoxLayout())
         self.tab_gantt_chart.layout().addWidget(self.gantt_container)
-        
+
         # 初始化圖表主題配置
         self.configure_chart_theme()
 
@@ -1349,7 +1350,7 @@ class BirdmanQtApp(QMainWindow):
         self.update_gantt_display()
 
         QMessageBox.information(
-            self, '完整分析完成', 
+            self, '完整分析完成',
             f'已完成所有情境的 CPM 分析，共生成 {len(self.gantt_results)} 種情境結果'
         )
 
@@ -1490,10 +1491,10 @@ class BirdmanQtApp(QMainWindow):
             wbs_df, role_key, time_key
         )
         self.critical_path = findCriticalPath(cpm_df)
-        
+
         # 更新關鍵路徑後，重繪合併後的依賴圖以顯示關鍵路徑
         self.redraw_merged_graph()
-        
+
         self.cmp_result_view.setModel(
             PandasModel(self.current_display_cpm_df.head(100))
         )
@@ -1605,13 +1606,13 @@ class BirdmanQtApp(QMainWindow):
             # 檢查是否有蒙地卡羅模擬正在進行
             is_simulation_running = False
             try:
-                is_simulation_running = (hasattr(self, 'mc_thread') and 
-                                       self.mc_thread is not None and
-                                       self.mc_thread.isRunning())
+                is_simulation_running = (hasattr(self, 'mc_thread') and
+                                         self.mc_thread is not None and
+                                         self.mc_thread.isRunning())
             except RuntimeError:
                 # QThread 已被刪除，表示模擬已完成
                 is_simulation_running = False
-            
+
             # 如果模擬正在進行，顯示警告並阻止切換
             if is_simulation_running:
                 # 恢復原始狀態
@@ -1619,16 +1620,16 @@ class BirdmanQtApp(QMainWindow):
                 self.dark_mode_action.setChecked(self.is_dark_mode)
                 self.dark_mode_action.blockSignals(False)
                 QMessageBox.warning(
-                    self, 
-                    '無法切換主題', 
+                    self,
+                    '無法切換主題',
                     '蒙地卡羅模擬進行中，請等待模擬完成後再進行任何操作。'
                 )
                 return
-            
+
             # 保存當前窗口狀態
             current_geometry = self.geometry()
             was_maximized = self.isMaximized()
-            
+
             if checked:
                 # 載入深色樣式表，包含標題欄
                 dark_style = qdarkstyle.load_stylesheet_pyqt5()
@@ -1662,7 +1663,7 @@ class BirdmanQtApp(QMainWindow):
             # 處理窗口幾何問題
             # 等待樣式應用完成
             QApplication.processEvents()
-            
+
             # 溫和地處理窗口狀態
             if was_maximized:
                 # 如果之前是最大化，重新最大化
@@ -1672,17 +1673,17 @@ class BirdmanQtApp(QMainWindow):
                 # 暫時放寬最小尺寸限制
                 self.setMinimumSize(600, 400)
                 QApplication.processEvents()
-                
+
                 # 嘗試恢復原始幾何，如果失敗則使用安全的尺寸
                 try:
                     self.setGeometry(current_geometry)
-                except:
+                except BaseException:
                     # 如果恢復失敗，使用安全的尺寸
                     self.resize(1200, 800)
-                
+
                 # 恢復合適的最小尺寸
                 self.setMinimumSize(800, 600)
-                
+
             # 再次處理事件以確保佈局正確
             QApplication.processEvents()
 
@@ -1694,7 +1695,9 @@ class BirdmanQtApp(QMainWindow):
                 self.gantt_figure.clear()
             if hasattr(self, 'graph_figure') and self.graph_figure:
                 self.graph_figure.clear()
-            if hasattr(self, 'merged_graph_figure') and self.merged_graph_figure:
+            if hasattr(
+                    self,
+                    'merged_graph_figure') and self.merged_graph_figure:
                 self.merged_graph_figure.clear()
             if hasattr(self, 'mc_figure') and self.mc_figure:
                 self.mc_figure.clear()
@@ -1703,14 +1706,14 @@ class BirdmanQtApp(QMainWindow):
             self.redraw_graph()
             if hasattr(self, 'gantt_results') and self.gantt_results:
                 self.update_gantt_display()
-            
+
             # 重繪蒙地卡羅圖表
             if hasattr(self, 'mc_last_results') and self.mc_last_results:
                 self.plot_results(self.mc_last_results)
             else:
                 # 如果沒有結果，重新初始化空白圖表
                 self.initialize_monte_carlo_chart()
-                
+
         except Exception as e:
             # 如果主題切換過程中出現任何錯誤，顯示錯誤訊息但不崩潰
             QMessageBox.warning(
@@ -1770,7 +1773,7 @@ class BirdmanQtApp(QMainWindow):
                         critical_path_edges = self.get_critical_path_edges(
                             self.merged_graph, self.critical_path
                         )
-                    
+
                     self.merged_graph_figure = (
                         visualizer.create_dependency_graph_figure(
                             self.merged_graph,
@@ -1800,15 +1803,18 @@ class BirdmanQtApp(QMainWindow):
         """專門重繪合併後的依賴關係圖（包含關鍵路徑資訊）"""
         if not hasattr(self, 'merged_graph') or self.merged_graph is None:
             return
-            
+
         try:
             with open('config.json', 'r', encoding='utf-8') as f:
                 config = json.load(f)
             viz_params = config.get('visualization_params', {})
 
             # 清除舊的合併圖 Canvas
-            for i in reversed(range(self.merged_graph_container_layout.count())):
-                old_widget = self.merged_graph_container_layout.itemAt(i).widget()
+            for i in reversed(
+                range(
+                    self.merged_graph_container_layout.count())):
+                old_widget = self.merged_graph_container_layout.itemAt(
+                    i).widget()
                 if old_widget:
                     old_widget.setParent(None)
 
@@ -1830,9 +1836,10 @@ class BirdmanQtApp(QMainWindow):
                 )
             )
             self.merged_graph_canvas = FigureCanvas(self.merged_graph_figure)
-            self.merged_graph_container_layout.addWidget(self.merged_graph_canvas)
+            self.merged_graph_container_layout.addWidget(
+                self.merged_graph_canvas)
             self.merged_graph_canvas.draw()
-            
+
             m_size = self.merged_graph_canvas.get_width_height()
             if m_size[0] > 0 and m_size[1] > 0:
                 self.merged_graph_container.setMinimumSize(
@@ -1884,21 +1891,21 @@ class BirdmanQtApp(QMainWindow):
             except RuntimeError:
                 # 線程已被刪除，繼續執行
                 pass
-        
+
         # 重置線程引用
         self.mc_thread = None
         self.mc_worker = None
 
         # 禁用深色模式切換
         self.dark_mode_action.setEnabled(False)
-        
+
         # 禁用分頁切換
         self.tabs_results.setEnabled(False)
         self.main_tabs.setEnabled(False)
-        
+
         # 禁用菜單欄
         self.menuBar().setEnabled(False)
-        
+
         self.mc_run_button.setEnabled(False)
         role_key = (
             'newbie'
@@ -1914,48 +1921,49 @@ class BirdmanQtApp(QMainWindow):
             self.merged_wbs, self.merged_graph, role_key, iterations
         )
         self.mc_worker.moveToThread(self.mc_thread)
-        
+
         # 連接信號
         self.mc_thread.started.connect(self.mc_worker.run)
         self.mc_worker.progress.connect(self.mc_progress_bar.setValue)
         self.mc_worker.finished.connect(self.simulation_finished)
         self.mc_worker.finished.connect(self.mc_thread.quit)
         self.mc_worker.finished.connect(self.mc_worker.deleteLater)
-        
+
         # 確保線程完全結束後清理
-        self.mc_thread.finished.connect(lambda: setattr(self, 'mc_thread', None))
+        self.mc_thread.finished.connect(
+            lambda: setattr(self, 'mc_thread', None))
         self.mc_thread.finished.connect(self.mc_thread.deleteLater)
-        
+
         self.mc_thread.start()
 
     def simulation_finished(self, results: list[float]) -> None:
         """模擬完成後處理結果"""
         try:
             self.mc_run_button.setEnabled(True)
-            
+
             # 重新啟用深色模式切換
             self.dark_mode_action.setEnabled(True)
-            
+
             # 重新啟用分頁切換
             self.tabs_results.setEnabled(True)
             self.main_tabs.setEnabled(True)
-            
+
             # 重新啟用菜單欄
             self.menuBar().setEnabled(True)
-            
+
             # 注意：線程引用將由信號連接自動清理，不要在這裡手動設置為 None
             # 這是因為 lambda: setattr(self, 'mc_thread', None) 會在線程完全結束後執行
-            
+
             if not results:
                 QMessageBox.information(self, '模擬完成', '無有效結果')
                 return
-            
+
             # 繪製結果
             self.plot_results(results)
-            
+
             # 額外確保 UI 更新
             QApplication.processEvents()
-            
+
             # 強制更新蒙地卡羅分頁
             self.tab_monte_carlo.update()
             self.tab_monte_carlo.repaint()
@@ -1972,11 +1980,14 @@ class BirdmanQtApp(QMainWindow):
         """顯示模擬結果"""
         # 保存結果以便深色模式切換時重繪
         self.mc_last_results = results
-        
+
         # 設定中文字體
-        plt.rcParams['font.sans-serif'] = ['Microsoft JhengHei', 'SimHei', 'Arial Unicode MS', 'sans-serif']
+        plt.rcParams['font.sans-serif'] = [
+            'Microsoft JhengHei', 'SimHei',
+            'Arial Unicode MS', 'sans-serif'
+        ]
         plt.rcParams['axes.unicode_minus'] = False
-        
+
         arr = np.array(results, dtype=float)
         avg = float(arr.mean())
         std = float(arr.std())
@@ -1992,11 +2003,7 @@ class BirdmanQtApp(QMainWindow):
 
         self.mc_figure.clear()
         ax = self.mc_figure.add_subplot(111)
-        
-        # 計算合適的bin寬度以增大直方圖條
-        range_val = arr.max() - arr.min()
-        bin_width = range_val / 25  # 減少bins數量以增大條寬
-        
+
         # 根據深色模式設定顏色
         if self.is_dark_mode:
             bar_color = 'lightblue'
@@ -2012,50 +2019,58 @@ class BirdmanQtApp(QMainWindow):
             # 設定圖表背景為淺色
             self.mc_figure.patch.set_facecolor('white')
             ax.set_facecolor('white')
-        
+
         # 繪製直方圖，增大條寬
         n, bins, patches = ax.hist(
-            arr, 
+            arr,
             bins=25,  # 減少bins數量
-            color=bar_color, 
+            color=bar_color,
             edgecolor=edge_color,
             alpha=0.8,
             rwidth=0.9  # 增大條的相對寬度
         )
-        
+
         # 獲取模擬條件資訊
         role_text = self.mc_role_select_combo.currentText()
         iterations = self.mc_iterations_spinbox.value()
-        
+
         # 設定標題，包含模擬條件
         title = f'蒙地卡羅模擬結果\n分析對象: {role_text} | 模擬次數: {iterations:,} 次'
         ax.set_title(title, color=text_color, fontsize=12, pad=15)
-        
+
         ax.set_xlabel('工時 (小時)', color=text_color, fontsize=10)
         ax.set_ylabel('頻率', color=text_color, fontsize=10)
-        
+
         # 設定刻度顏色
         ax.tick_params(colors=text_color)
-        
+
         # 在圖表上添加統計資訊文字
         stats_text = f'平均: {avg:.1f}h\n標準差: {std:.1f}h\n中位數: {p50:.1f}h'
-        ax.text(0.02, 0.98, stats_text, transform=ax.transAxes, 
-               verticalalignment='top', fontsize=9,
-               bbox=dict(boxstyle='round', facecolor='white' if not self.is_dark_mode else '#404040', 
-                        alpha=0.8, edgecolor=text_color),
-               color=text_color)
-        
+        ax.text(
+            0.02,
+            0.98,
+            stats_text,
+            transform=ax.transAxes,
+            verticalalignment='top',
+            fontsize=9,
+            bbox=dict(
+                boxstyle='round',
+                facecolor='white' if not self.is_dark_mode else '#404040',
+                alpha=0.8,
+                edgecolor=text_color),
+            color=text_color)
+
         # 調整布局
         self.mc_figure.tight_layout()
-        
+
         # 強制重繪和更新畫布
         self.mc_canvas.draw()
         self.mc_canvas.flush_events()
-        
+
         # 確保 widget 更新
         self.mc_canvas.update()
         self.mc_canvas.repaint()
-        
+
         # 處理所有待處理的事件
         QApplication.processEvents()
 
@@ -2064,7 +2079,7 @@ class BirdmanQtApp(QMainWindow):
         if not hasattr(self, 'mc_figure') or self.mc_figure is None:
             QMessageBox.warning(self, '警告', '請先執行蒙地卡羅模擬')
             return
-            
+
         if not hasattr(self, 'mc_last_results') or not self.mc_last_results:
             QMessageBox.warning(self, '警告', '沒有可匯出的模擬結果')
             return
@@ -2089,16 +2104,19 @@ class BirdmanQtApp(QMainWindow):
             QMessageBox.information(self, '完成', f'已匯出蒙地卡羅圖表至：{path}')
         except (OSError, ValueError) as e:
             QMessageBox.critical(self, '錯誤', f'匯出圖檔時發生錯誤：{e}')
-            
+
     def initialize_monte_carlo_chart(self):
         """初始化蒙地卡羅圖表，設定適當的背景色"""
         self.mc_figure.clear()
         ax = self.mc_figure.add_subplot(111)
-        
+
         # 設定中文字體
-        plt.rcParams['font.sans-serif'] = ['Microsoft JhengHei', 'SimHei', 'Arial Unicode MS', 'sans-serif']
+        plt.rcParams['font.sans-serif'] = [
+            'Microsoft JhengHei', 'SimHei',
+            'Arial Unicode MS', 'sans-serif'
+        ]
         plt.rcParams['axes.unicode_minus'] = False
-        
+
         # 根據當前模式設定顏色
         if self.is_dark_mode:
             text_color = 'white'
@@ -2108,20 +2126,20 @@ class BirdmanQtApp(QMainWindow):
             text_color = 'black'
             self.mc_figure.patch.set_facecolor('white')
             ax.set_facecolor('white')
-        
+
         # 設定空白圖表的標題和標籤
         ax.set_title('蒙地卡羅模擬結果\n(請先執行模擬)', color=text_color, fontsize=12)
         ax.set_xlabel('工時 (小時)', color=text_color, fontsize=10)
         ax.set_ylabel('頻率', color=text_color, fontsize=10)
-        
+
         # 設定刻度顏色
         ax.tick_params(colors=text_color)
-        
+
         # 添加提示文字
-        ax.text(0.5, 0.5, '點擊「開始模擬」按鈕\n進行蒙地卡羅分析', 
-               transform=ax.transAxes, ha='center', va='center',
-               fontsize=14, color=text_color, alpha=0.6)
-        
+        ax.text(0.5, 0.5, '點擊「開始模擬」按鈕\n進行蒙地卡羅分析',
+                transform=ax.transAxes, ha='center', va='center',
+                fontsize=14, color=text_color, alpha=0.6)
+
         self.mc_figure.tight_layout()
         self.mc_canvas.draw()
 
@@ -2185,13 +2203,13 @@ class BirdmanQtApp(QMainWindow):
 
 def main():
     app = QApplication(sys.argv)
-    
+
     # 設置應用程式退出時清理所有 QThread
     app.setQuitOnLastWindowClosed(True)
-    
+
     window = BirdmanQtApp()
     window.show()
-    
+
     try:
         exit_code = app.exec_()
     finally:
@@ -2203,7 +2221,7 @@ def main():
                     window.mc_thread.wait(2000)  # 等待2秒
             except (RuntimeError, AttributeError):
                 pass
-    
+
     sys.exit(exit_code)
 
 

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -101,9 +101,13 @@ def create_dependency_graph_figure(
     # 2. 繪製邊線
     if critical_path_edges:
         # 分別繪製關鍵路徑和非關鍵路徑的邊線
-        critical_edges = [(u, v) for u, v in G.edges() if (u, v) in critical_path_edges]
-        non_critical_edges = [(u, v) for u, v in G.edges() if (u, v) not in critical_path_edges]
-        
+        critical_edges = [
+            (u, v) for u, v in G.edges() if (
+                u, v) in critical_path_edges]
+        non_critical_edges = [
+            (u, v) for u, v in G.edges() if (
+                u, v) not in critical_path_edges]
+
         # 繪製非關鍵路徑邊線（使用預設顏色）
         if non_critical_edges:
             nx.draw_networkx_edges(
@@ -119,7 +123,7 @@ def create_dependency_graph_figure(
                 connectionstyle='arc3,rad=0.1',
                 node_size=node_size,
             )
-        
+
         # 繪製關鍵路徑邊線（紅色）
         if critical_edges:
             nx.draw_networkx_edges(


### PR DESCRIPTION
## 摘要
- 清理 GUI 相關程式的空白與縮排，消除 flake8 警告
- 拆分過長列並移除未使用變數
- 視覺化模組調整清單推導格式以通過 flake8

## 測試
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e24959af88323b0781d4efe346513