### PR TITLE
修正 CLI 參數為 --cpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv --config conf
 ```
 
 執行後會在目前目錄產生 `sorted_wbs.csv`、`merged_wbs.csv` 及 `sorted_dsm.csv`。
-若加上 `--cmp` 參數，會同時輸出 `cmp_analysis.csv`，並可使用 `--export-gantt` 匯出甘特圖、`--export-graph` 匯出依賴關係圖。工期欄位預設採用 `config.json` 中的 `default_duration_field`（預設 `Te_newbie`），亦可透過 `--duration-field` 指定。
+若加上 `--cpm` 參數，會同時輸出 `cmp_analysis.csv`，並可使用 `--export-gantt` 匯出甘特圖、`--export-graph` 匯出依賴關係圖。工期欄位預設採用 `config.json` 中的 `default_duration_field`（預設 `Te_newbie`），亦可透過 `--duration-field` 指定。
 若需評估工期分佈，可加入 `--monte-carlo 500` 執行 500 次模擬，信心水準可用 `--mc-confidence 0.9` 指定（預設為 0.9）。
 
 若需執行資源受限排程，可加入 `--rcpsp-opt`，將產生 `rcpsp_schedule.csv`。

--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ def main():
     parser.add_argument("--dsm", required=True)
     parser.add_argument("--wbs", required=True)
     parser.add_argument("--config", default="config.json")
-    parser.add_argument("--cmp", action="store_true", help="執行 CPM 分析")
+    parser.add_argument("--cpm", action="store_true", help="執行 CPM 分析")
     parser.add_argument(
         "--export-graph",
         metavar="PATH",
@@ -92,7 +92,7 @@ def main():
     parser.add_argument(
         "--export-gantt",
         metavar="PATH",
-        help="匯出甘特圖 (SVG 或 PNG)，需同時啟用 --cmp"
+        help="匯出甘特圖 (SVG 或 PNG)，需同時啟用 --cpm"
     )
     parser.add_argument(
         "--duration-field",
@@ -186,7 +186,7 @@ def main():
         saveFigure(fig, args.export_graph)
         print(f"已匯出依賴關係圖至 {args.export_graph}")
 
-    if args.cmp:
+    if args.cpm:
         print("開始執行 CPM 分析...")
         cmp_params = config.get('cmp_params', {})
         duration_field = args.duration_field or cmp_params.get(

--- a/tests/test_cli_cpm.py
+++ b/tests/test_cli_cpm.py
@@ -22,7 +22,7 @@ def test_cli_cpm(tmp_path):
         '--dsm', str(dsm_path),
         '--wbs', str(wbs_path),
         '--config', str(ROOT / 'config.json'),
-        '--cmp'
+        '--cpm'
     ]
     subprocess.run(cmd, check=True, cwd=tmp_path)
     assert (tmp_path / 'cmp_analysis.csv').exists()


### PR DESCRIPTION
## Summary
- 將 CLI 參數 `--cmp` 更名為 `--cpm`
- 更新 README 與測試腳本中的旗標說明

## Testing
- `flake8` *(失敗：src/gui_qt.py 現存格式問題)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed63721b48323ab42e0fe6667a474