### PR TITLE
feat: 支援 RCPSP 資源排程

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@
 
 4. **RCPSP 排程**
    - 透過 OR-Tools 求解資源受限排程
-   - WBS 支援 `ResourceDemand` 欄位，可設定每個任務所需資源單位
-   - 使用 --rcpsp-opt 取得優化結果
+   - 需提供 Resources.csv 以計算各資源容量
+   - WBS 必須包含資源欄位（預設 `Category`）與 `ResourceDemand` 欄位
+   - 使用 `--rcpsp-opt` 搭配 `--resources` 取得優化結果
 
 5. **匯出功能**
    - 支援 SVG/PNG 格式
@@ -139,10 +140,17 @@ python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv --config conf
 ```
 
 執行後會在目前目錄產生 `sorted_wbs.csv`、`merged_wbs.csv` 及 `sorted_dsm.csv`。
+若需同時考量資源限制，可執行：
+
+```bash
+python main.py --dsm sample_data/DSM.csv --wbs sample_data/WBS.csv \
+    --resources sample_data/Resources.csv --config config.json --rcpsp-opt \
+    --export-rcpsp-gantt rcpsp.png
+```
 若加上 `--cpm` 參數，會同時輸出 `cmp_analysis.csv`，並可使用 `--export-gantt` 匯出甘特圖、`--export-graph` 匯出依賴關係圖。工期欄位預設採用 `config.json` 中的 `default_duration_field`（預設 `Te_newbie`），亦可透過 `--duration-field` 指定。
 若需評估工期分佈，可加入 `--monte-carlo 500` 執行 500 次模擬，信心水準可用 `--mc-confidence 0.9` 指定（預設為 0.9）。
 
-若需執行資源受限排程，可加入 `--rcpsp-opt`，將產生 `rcpsp_schedule.csv`。若同時使用 `--export-rcpsp-gantt PATH`，可將資源受限排程的結果匯出為甘特圖。
+若需執行資源受限排程，請加上 `--rcpsp-opt` 並指定 `--resources Resources.csv`，WBS 需提供資源欄位與 `ResourceDemand` 欄位。執行後會產生 `rcpsp_schedule.csv`，若同時使用 `--export-rcpsp-gantt PATH`，可將結果匯出為甘特圖。
 
 ### GUI（推薦 PyQt5 進階版）
 
@@ -165,7 +173,7 @@ python src/ui/main_window.py
 
 1. **檔案操作**
 
-   - 支援選擇 DSM/WBS 檔案
+   - 支援選擇 DSM/WBS/Resources 檔案
    - 即時預覽資料內容
    - CSV 格式匯出結果
    - 匯出合併後 DSM（CSV 與 Excel）

--- a/tests/test_cli_rcpsp.py
+++ b/tests/test_cli_rcpsp.py
@@ -1,0 +1,48 @@
+import subprocess
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN = ROOT / "main.py"
+
+
+def test_cli_rcpsp(tmp_path):
+    """測試 CLI RCPSP 排程與甘特圖輸出"""
+    dsm_path = tmp_path / "dsm.csv"
+    wbs_path = tmp_path / "wbs.csv"
+    res_path = tmp_path / "Resources.csv"
+
+    dsm_data = "Task ID,A,B\nA,0,0\nB,0,0\n"
+    dsm_path.write_text(dsm_data, encoding="utf-8")
+
+    wbs_data = (
+        "Task ID,TRF,Te_newbie,Category,ResourceDemand\n"
+        "A,1,2,R1,1\n"
+        "B,1,3,R1,1\n"
+    )
+    wbs_path.write_text(wbs_data, encoding="utf-8")
+
+    res_data = "Group,Headcount_Cap\nR1,1\n"
+    res_path.write_text(res_data, encoding="utf-8")
+
+    gantt_path = tmp_path / "gantt.png"
+
+    cmd = [
+        sys.executable,
+        str(MAIN),
+        "--dsm",
+        str(dsm_path),
+        "--wbs",
+        str(wbs_path),
+        "--resources",
+        str(res_path),
+        "--config",
+        str(ROOT / "config.json"),
+        "--rcpsp-opt",
+        "--export-rcpsp-gantt",
+        str(gantt_path),
+    ]
+    subprocess.run(cmd, check=True, cwd=tmp_path)
+    assert (tmp_path / "rcpsp_schedule.csv").exists()
+    assert gantt_path.exists()


### PR DESCRIPTION
## Summary
- 新增 --resources、資源欄位與需求欄位參數，載入資源容量後呼叫 RCPSP 求解
- GUI 可匯入 Resources 檔案並顯示 RCPSP 甘特圖
- 文件補充 RCPSP 使用方式並新增 CLI 測試

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f700339b083239dec4cbbd5a530f7