### PR TITLE
feat(ui): keep edges attached during node resize

### DIFF
--- a/src/ui/dsm_editor.py
+++ b/src/ui/dsm_editor.py
@@ -353,12 +353,6 @@ class ResizeHandle(QGraphicsRectItem):
             if hasattr(self.parent_node.editor, 'state'):
                 self.parent_node.editor.state = EditorState.IDLE
 
-            # 最終更新連接的邊（批量執行）
-            if hasattr(self.parent_node, '_edges_need_update') and self.parent_node._edges_need_update:
-                for edge in self.parent_node.edges:
-                    edge.updatePath()
-                self.parent_node._edges_need_update = False
-
             event.accept()
         else:
             super().mouseReleaseEvent(event)
@@ -438,8 +432,9 @@ class ResizeHandle(QGraphicsRectItem):
             # 批量更新把手位置（不觸發個別重繪）
             self.parent_node._updateHandlesPositionQuiet()
 
-        # 標記需要更新連線（但不立即更新，避免頻繁重繪）
-        self.parent_node._edges_need_update = True
+        # 即時更新與節點相連的邊，確保縮放過程中連線緊貼節點
+        for edge in self.parent_node.edges:
+            edge.updatePath()
 
 
 class CanvasView(QGraphicsView):


### PR DESCRIPTION
## Summary
- 更新節點縮放流程，改為即時更新相關連線，避免暫時脫離節點
- 簡化縮放結束邏輯，釋放滑鼠時不再進行額外的邊線批次更新

## Testing
- `pytest` *(失敗：cannot import name 'layered_layout' from 'src.visualizer')*

------
https://chatgpt.com/codex/tasks/task_e_689446c6a0f88323af7823a63b45c7e9