### PR TITLE
feat(ui): 新增佈局與繞線引擎包裝層

### DIFF
--- a/src/ui/layout_engine.py
+++ b/src/ui/layout_engine.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from typing import Dict, Tuple, Set
+import pandas as pd
+
+# 佈局演算法：沿用現有實作，不改對外位置
+from src.layouts.hierarchical import layout_hierarchical
+
+# 統一回傳介面：positions = {task_id: (x, y)}
+def apply_hierarchical(wbs_df: pd.DataFrame,
+                       edges: Set[Tuple[str, str]],
+                       grid: int = 10) -> Dict[str, Tuple[float, float]]:
+    """
+    統一封裝分層佈局。不得改動外部欄位與資料結構。
+    """
+    # 現有實作尚未支援網格參數，因此暫忽略 grid 值
+    return layout_hierarchical(wbs_df, edges)
+
+
+def apply_force_directed(*args, **kwargs):
+    """預留介面，尚未接入。"""
+    raise NotImplementedError

--- a/src/ui/router_engine.py
+++ b/src/ui/router_engine.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from typing import Dict, List, Tuple
+from PyQt5.QtCore import QPointF, QRectF
+
+# 沿用既有邊線繞線引擎
+from src.edge_routing import EdgeRoutingEngine
+
+
+def route_all(nodes: Dict[str, QRectF],
+              edges: List[Tuple[str, str]]) -> Dict[Tuple[str, str], List[QPointF]]:
+    """
+    封裝批次繞線。不得引入 solver/processor 的任何依賴。
+    nodes: {node_id: QRectF} 以場景座標為準
+    edges: [(src_id, dst_id)]
+    回傳：{(src_id, dst_id): [QPointF, ...]}
+    """
+    engine = EdgeRoutingEngine()
+    obstacles = [(rect, nid) for nid, rect in nodes.items()]
+    engine.set_obstacles(obstacles)
+
+    def center(r: QRectF) -> QPointF:
+        return QPointF(r.center().x(), r.center().y())
+
+    result: Dict[Tuple[str, str], List[QPointF]] = {}
+    for (s, d) in edges:
+        p0 = center(nodes[s])
+        p1 = center(nodes[d])
+        path = engine.route_edge(p0, p1)
+        points = [QPointF(path.elementAt(i).x, path.elementAt(i).y)
+                  for i in range(path.elementCount())]
+        result[(s, d)] = points
+    return result


### PR DESCRIPTION
## Summary
- 建立 `layout_engine` 以封裝既有階層式佈局
- 建立 `router_engine` 以批次呼叫邊線繞線引擎

## Testing
- `pytest` *(Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6896efb6c6cc8323857c1591343875b4